### PR TITLE
refactor: use remote action and secret project

### DIFF
--- a/.github/workflows/deploy-preview-with-version.yml
+++ b/.github/workflows/deploy-preview-with-version.yml
@@ -25,11 +25,11 @@ jobs:
       - uses: actions/checkout@v5
       - name: Deploy to Firebase Hosting preview channel
         id: firebase_hosting_preview
-        uses: ./
+        uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
           expires: 14d
-          projectId: action-hosting-deploy-demo
+          projectId: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
           entryPoint: "./demo"
           firebaseToolsVersion: v11.12.0

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -25,12 +25,12 @@ jobs:
       - uses: actions/checkout@v5
       - name: Deploy to Firebase Hosting preview channel
         id: firebase_hosting_preview
-        uses: ./
+        uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
           expires: 14d
-          projectId: action-hosting-deploy-demo
+          projectId: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
           entryPoint: "./demo"
       - name: Check outputs
         run: |


### PR DESCRIPTION
## Summary
- use hosted action from FirebaseExtended for preview workflows
- source preview project from VITE_FIREBASE_PROJECT_ID secret

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae4f884dcc83248d50916924bd4a54