### PR TITLE
Use official Firebase deploy action

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -11,9 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       # - run: npm run build
-      - uses: ./
+      - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
           channelId: live
-          projectId: action-hosting-deploy-demo
+          projectId: "${{ secrets.VITE_FIREBASE_PROJECT_ID }}"
           entryPoint: "./demo"


### PR DESCRIPTION
## Summary
- use FirebaseExtended/action-hosting-deploy@v0 in production workflow
- pull projectId from VITE_FIREBASE_PROJECT_ID secret

## Testing
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae4f9606bc8324a12471467f37c56b