### PR TITLE
chore: use secret for firebase project id

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: Main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./
+        with:
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
+          channelId: live
+          projectId: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          entryPoint: "./demo"


### PR DESCRIPTION
## Summary
- add main workflow using VITE_FIREBASE_PROJECT_ID secret for Firebase project

## Testing
- `npm test`
- `gh secret list` *(fails: requires authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4fa5fc588324a1fabefb56827301