### PR TITLE
chore: use Node 20 in CI workflows

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - name: Install dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - name: Install dependencies
         run: npm ci
       - name: Check that Prettier was run


### PR DESCRIPTION
## Summary
- ensure check-build workflow installs Node 20
- ensure test workflow installs Node 20

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae4fa999488324a684e90e01fcf12b